### PR TITLE
add cert install for mac/linux

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,3 +18,12 @@ make \
     NO_GETTEXT=1 \
     NO_INSTALL_HARDLINKS=1 \
     all strip install
+
+curl https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt -o $PREFIX/bin/ca-bundle.crt
+
+mkdir -p $PREFIX/etc
+cat > $PREFIX/etc/gitconfig <<endmsg
+[http]
+    sslVerify = true
+    sslCAinfo = $PREFIX/bin/ca-bundle.crt
+endmsg


### PR DESCRIPTION
This fixes HTTPS checkouts for mac, which is important since they're the anonymous option.