### PR TITLE
OLD: NO MRG: Use certs for Unix platforms

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,9 +25,6 @@ make \
     NO_INSTALL_HARDLINKS=1 \
     all strip install
 
-mkdir -p $PREFIX/etc
-cat > $PREFIX/etc/gitconfig <<endmsg
-[http]
-    sslVerify = true
-    sslCAinfo = $PREFIX/ssl/cacert.pem
-endmsg
+git config --system http.sslVerify true
+git config --system http.sslCAPath "${PREFIX}/ssl/cacert.pem"
+git config --system http.sslCAfile "${PREFIX}/ssl/cacert.pem"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,4 +27,4 @@ make \
 
 git config --system http.sslVerify true
 git config --system http.sslCAPath "${PREFIX}/ssl/cacert.pem"
-git config --system http.sslCAFile "${PREFIX}/ssl/cacert.pem"
+git config --system http.sslCAInfo "${PREFIX}/ssl/cacert.pem"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,7 @@ mkdir -p $PREFIX/etc
 make configure
 ./configure \
     --prefix="${PREFIX}" \
+    --with-gitattributes="${PREFIX}/etc/gitattributes" \
     --with-gitconfig="${PREFIX}/etc/gitconfig"
 make \
     --jobs="$CPU_COUNT" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,4 +27,4 @@ make \
 
 git config --system http.sslVerify true
 git config --system http.sslCAPath "${PREFIX}/ssl/cacert.pem"
-git config --system http.sslCAfile "${PREFIX}/ssl/cacert.pem"
+git config --system http.sslCAFile "${PREFIX}/ssl/cacert.pem"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,3 +18,10 @@ make \
     NO_GETTEXT=1 \
     NO_INSTALL_HARDLINKS=1 \
     all strip install
+
+mkdir -p $PREFIX/etc
+cat > $PREFIX/etc/gitconfig <<endmsg
+[http]
+    sslVerify = true
+    sslCAinfo = $PREFIX/ssl/cacert.pem
+endmsg

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,8 +9,13 @@ export LIBRARY_PATH="${PREFIX}/lib"
 #   /ref http://www.spinics.net/lists/git/msg99803.html
 # NO_GETTEXT disables internationalization (localized message translations)
 # NO_INSTALL_HARDLINKS uses symlinks which makes the package 85MB slimmer (8MB instead of 93MB!)
+
+# Add a place for git config files.
+mkdir -p $PREFIX/etc
 make configure
-./configure --prefix="${PREFIX}"
+./configure \
+    --prefix="${PREFIX}" \
+    --with-gitconfig="${PREFIX}/etc/gitconfig"
 make \
     --jobs="$CPU_COUNT" \
     NO_TCLTK=1 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,8 @@ requirements:
 test:
   commands:
     # FIXME: Please remove me once we have fixed git and curl.
-    - cat /opt/conda/envs/_test/etc/gitconfig                                 # [unix]
-    - grep -r "/opt/conda/envs/_build/ssl/cacert.pem" /opt/conda/envs/_test/  # [unix]
+    - cat "${PREFIX}/etc/gitconfig"                                # [unix]
+    - grep -r "/opt/conda/envs/_build/ssl/cacert.pem" "${PREFIX}"  # [unix]
 
     # Actual tests to keep (delete this comment when done too).
     - git --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,11 +33,6 @@ requirements:
 
 test:
   commands:
-    # FIXME: Please remove me once we have fixed git and curl.
-    - cat "${PREFIX}/etc/gitconfig"                                # [unix]
-    - grep -r "/opt/conda/envs/_build/ssl/cacert.pem" "${PREFIX}"  # [unix]
-
-    # Actual tests to keep (delete this comment when done too).
     - git --version
     - git clone https://github.com/conda-forge/git-feedstock
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,14 @@ build:
 requirements:
   build:
     - autoconf    # [unix]
-    - expat       # [unix]
     - curl        # [unix]
+    - expat       # [unix]
     - openssl     # [unix]
     - zlib        # [unix]
     - 7za         # [win]
   run:
     - expat       # [unix]
+    - certifi     # [unix]
     - curl        # [unix]
     - openssl     # [unix]
     - zlib        # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ requirements:
     - zlib        # [unix]
     - 7za         # [win]
   run:
-    - expat       # [unix]
     - certifi     # [unix]
     - curl        # [unix]
+    - expat       # [unix]
     - openssl     # [unix]
     - zlib        # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
 test:
   commands:
     # FIXME: Please remove me once we have fixed git and curl.
+    - cat /opt/conda/envs/_test/etc/gitconfig                                 # [unix]
     - grep -r "/opt/conda/envs/_build/ssl/cacert.pem" /opt/conda/envs/_test/  # [unix]
 
     # Actual tests to keep (delete this comment when done too).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: da25bc12efa864cda53dc6485c84dd8b0d41883dd360db505c026c284ef58d8e                                                        # [win]
 
 build:
-  number: 0
+  number: 1
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,10 @@ requirements:
 
 test:
   commands:
+    # FIXME: Please remove me once we have fixed git and curl.
+    - grep -r "/opt/conda/envs/_build/ssl/cacert.pem" /opt/conda/envs/_test/  # [unix]
+
+    # Actual tests to keep (delete this comment when done too).
     - git --version
     - git clone https://github.com/conda-forge/git-feedstock
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - zlib        # [unix]
     - 7za         # [win]
   run:
-    - certifi     # [unix]
     - curl        # [unix]
     - expat       # [unix]
     - openssl     # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
 test:
   commands:
     - git --version
+    - git clone https://github.com/conda-forge/git-feedstock
 
 about:
   home: https://git-scm.com/


### PR DESCRIPTION
Pulled from this nice work ( https://github.com/conda-forge/git-feedstock/pull/6 ) by @msarahan. Required some tweaks to remove MSYS2 stuff for now and to remove conflicts.

The `certifi` package provides certs as pointed at by @groutr. This is the simplest way for us to get them. So, we just install them and configure `git` to use them. This is only necessary for UNIX as PortableGit ships with certs.