### PR TITLE
Use certs for Unix platforms

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,8 +9,14 @@ export LIBRARY_PATH="${PREFIX}/lib"
 #   /ref http://www.spinics.net/lists/git/msg99803.html
 # NO_GETTEXT disables internationalization (localized message translations)
 # NO_INSTALL_HARDLINKS uses symlinks which makes the package 85MB slimmer (8MB instead of 93MB!)
+
+# Add a place for git config files.
+mkdir -p $PREFIX/etc
 make configure
-./configure --prefix="${PREFIX}"
+./configure \
+    --prefix="${PREFIX}" \
+    --with-gitattributes="${PREFIX}/etc/gitattributes" \
+    --with-gitconfig="${PREFIX}/etc/gitconfig"
 make \
     --jobs="$CPU_COUNT" \
     NO_TCLTK=1 \
@@ -18,3 +24,7 @@ make \
     NO_GETTEXT=1 \
     NO_INSTALL_HARDLINKS=1 \
     all strip install
+
+git config --system http.sslVerify true
+git config --system http.sslCAPath "${PREFIX}/ssl/cacert.pem"
+git config --system http.sslCAInfo "${PREFIX}/ssl/cacert.pem"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,17 +19,17 @@ build:
 
 requirements:
   build:
-    - autoconf    # [unix]
-    - curl        # [unix]
-    - expat       # [unix]
-    - openssl     # [unix]
-    - zlib        # [unix]
-    - 7za         # [win]
+    - autoconf        # [unix]
+    - curl            # [unix]
+    - expat           # [unix]
+    - openssl  1.0*   # [unix]
+    - zlib     1.2*   # [unix]
+    - 7za             # [win]
   run:
-    - curl        # [unix]
-    - expat       # [unix]
-    - openssl     # [unix]
-    - zlib        # [unix]
+    - curl            # [unix]
+    - expat           # [unix]
+    - openssl  1.0*   # [unix]
+    - zlib     1.2*   # [unix]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,14 @@ build:
 requirements:
   build:
     - autoconf    # [unix]
-    - expat       # [unix]
     - curl        # [unix]
+    - expat       # [unix]
     - openssl     # [unix]
     - zlib        # [unix]
     - 7za         # [win]
   run:
-    - expat       # [unix]
     - curl        # [unix]
+    - expat       # [unix]
     - openssl     # [unix]
     - zlib        # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: da25bc12efa864cda53dc6485c84dd8b0d41883dd360db505c026c284ef58d8e                                                        # [win]
 
 build:
-  number: 0
+  number: 1
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
 test:
   commands:
     - git --version
+    - git clone https://github.com/conda-forge/git-feedstock
 
 about:
   home: https://git-scm.com/


### PR DESCRIPTION
Closes https://github.com/conda-forge/git-feedstock/pull/7
Fixes https://github.com/conda-forge/git-feedstock/issues/8

This replaces PR ( https://github.com/conda-forge/git-feedstock/pull/7 ) and cleans up the work we did there.

Here we configure `git` to use certificates to ensure it is able to clone using SSL. As the certificates (a separate package, `ca-certificates`) are pulled in as a dependency of `openssl`, we are guaranteed to have them through that dependency.

We first add a test that should fail without certificates. Then we make the changes needed to fix it.

Also, pinned this properly to match the [pinning wiki]( https://github.com/conda-forge/staged-recipes/wiki/Pinned-dependencies ).

cc  @msarahan @pelson