### PR TITLE
Use our libiconv

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,8 @@ make configure
 ./configure \
     --prefix="${PREFIX}" \
     --with-gitattributes="${PREFIX}/etc/gitattributes" \
-    --with-gitconfig="${PREFIX}/etc/gitconfig"
+    --with-gitconfig="${PREFIX}/etc/gitconfig" \
+    --with-iconv="${PREFIX}/lib"
 make \
     --jobs="$CPU_COUNT" \
     NO_TCLTK=1 \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,14 @@
 export C_INCLUDE_PATH="${PREFIX}/include"
 export LIBRARY_PATH="${PREFIX}/lib"
 
+if [ "$(uname)" == "Darwin" ]
+then
+    export LDFLAGS="-Wl,-rpath,$PREFIX/lib"
+elif [ "$(uname)" == "Linux" ]
+then
+    export LDFLAGS="-Wl,-rpath=$PREFIX/lib"
+fi
+
 # NO_TCLTK disables git-gui
 # NO_PERL disables all perl-based utils:
 #   git-instaweb, gitweb, git-cvsserver, git-svn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   sha256: 553acbf46bacc67c73b954689ad3d9ac294bf9cbe249a5b78159a1f92f37105b                                                        # [win64]
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and not py27]
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - autoconf        # [unix]
     - curl            # [unix]
     - expat           # [unix]
+    - libiconv        # [unix]
     - openssl 1.0.*   # [unix]
     - zlib 1.2.*      # [unix]
     - 7za             # [win]
@@ -35,6 +36,7 @@ requirements:
   run:
     - curl            # [unix]
     - expat           # [unix]
+    - libiconv        # [unix]
     - openssl 1.0.*   # [unix]
     - zlib 1.2.*      # [unix]
 


### PR DESCRIPTION
Tries to use our `libiconv` instead of the system one. Particularly trying to fix OS X builds.
