### PR TITLE
Remove VC skip on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_vc14
+    - CONFIG: win_
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_c_compilergcc.yaml
+++ b/.ci_support/linux_c_compilergcc.yaml
@@ -9,7 +9,7 @@ channel_targets:
 curl:
 - '7.59'
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 expat:
 - '2.2'
 libiconv:

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -2,8 +2,3 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-pin_run_as_build:
-  vc:
-    max_pin: x
-vc:
-- '14'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 419fc2141b5d17c5ad73d9b2306cd3b2f5114c50bd67558cdc538da2c8e67b66  # [win64]
 
 build:
-  number: 1000
+  number: 1001
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ build:
   number: 1000
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
-  # we don't actually build on windows, don't need multiple VC builds
-  skip: true  # [win and vc!=14]
 
 requirements:
   build:


### PR DESCRIPTION
Currently we have a `skip` when `vc != 14`, which makes conda-smithy think we actually care about the VC version on Windows. But we don't, because we're just repackaging....