### PR TITLE
include manpages

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,8 @@
 # pcre-feedstock recipe does not include --enable-jit
 export NO_LIBPCRE1_JIT=1
 
+pushd code
+
 # Add a place for git config files.
 mkdir -p $PREFIX/etc
 make configure
@@ -37,4 +39,7 @@ git config --system http.sslCAInfo "${PREFIX}/ssl/cacert.pem"
 mkdir -p $PREFIX/share/bash-completion/completions
 cp contrib/completion/git-completion.bash $PREFIX/share/bash-completion/completions/git
 
+popd # code
 
+# Install manpages
+cp -r manpages/* $PREFIX/man

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,4 +42,5 @@ cp contrib/completion/git-completion.bash $PREFIX/share/bash-completion/completi
 popd # code
 
 # Install manpages
+mkdir -p $PREFIX/man
 cp -r manpages/* $PREFIX/man

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - gettext   # [unix]
     - libiconv  # [unix]
     - openssl   # [unix]
-    - pcre      # []unix
+    - pcre      # [unix]
     - perl      # [unix]
     - tk        # [unix]
     - zlib      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,16 +6,17 @@ package:
 
 source:
   - url: https://github.com/git/git/archive/v{{ version }}.tar.gz  # [not win]
-    folder: code # [not win]
+    folder: code  # [not win]
     sha256: 7d84f5d6f48e95b467a04a8aa1d474e0d21abc7877998af945568d2634fea46a  # [not win]
-    patches:                                              # [not win]
+    patches:  # [not win]
       - 0001-macOS-Do-not-use-the-system-Wish-urgh.patch  # [not win]
-  - url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-{{ version }}.tar.gz # [not win]
-    folder: manpages # [not win]
-    sha256: a5b0998f95c2290386d191d34780d145ea67e527fac98541e0350749bf76be75 # [not win]
+  - url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-{{ version }}.tar.gz  # [not win]
+    folder: manpages  # [not win]
+    sha256: a5b0998f95c2290386d191d34780d145ea67e527fac98541e0350749bf76be75  # [not win]
 
-  url: https://github.com/git-for-windows/git/releases/download/v{{ version }}.windows.1/PortableGit-{{ version }}-64-bit.7z.exe  # [win64]
-  sha256: 501d8be861ebb8694df3f47f1f673996b1d1672e12559d4a07fae7a2eca3afc7  # [win64]
+  - url: https://github.com/git-for-windows/git/releases/download/v{{ version }}.windows.1/PortableGit-{{ version }}-64-bit.7z.exe  # [win64]
+    folder: .  # [win64]
+    sha256: 501d8be861ebb8694df3f47f1f673996b1d1672e12559d4a07fae7a2eca3afc7  # [win64]
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,16 +5,20 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/git/git/archive/v{{ version }}.tar.gz  # [not win]
-  sha256: 7d84f5d6f48e95b467a04a8aa1d474e0d21abc7877998af945568d2634fea46a  # [not win]
-  patches:                                              # [not win]
-    - 0001-macOS-Do-not-use-the-system-Wish-urgh.patch  # [not win]
+  - url: https://github.com/git/git/archive/v{{ version }}.tar.gz  # [not win]
+    folder: code # [not win]
+    sha256: 7d84f5d6f48e95b467a04a8aa1d474e0d21abc7877998af945568d2634fea46a  # [not win]
+    patches:                                              # [not win]
+      - 0001-macOS-Do-not-use-the-system-Wish-urgh.patch  # [not win]
+  - url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-{{ version }}.tar.gz # [not win]
+    folder: manpages # [not win]
+    sha256: a5b0998f95c2290386d191d34780d145ea67e527fac98541e0350749bf76be75 # [not win]
 
   url: https://github.com/git-for-windows/git/releases/download/v{{ version }}.windows.1/PortableGit-{{ version }}-64-bit.7z.exe  # [win64]
   sha256: 501d8be861ebb8694df3f47f1f673996b1d1672e12559d4a07fae7a2eca3afc7  # [win64]
 
 build:
-  number: 1
+  number: 2
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
 
@@ -68,10 +72,13 @@ test:
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
+    # confirm toplevel manpage
+    - test -f $PREFIX/man/man1/git.1  # [not win]
+
 about:
   home: https://git-scm.com/
   license: GPL v2 and LGPL 2.1
-  license_file: COPYING  # [not win]
+  license_file: code/COPYING  # [not win]
   summary: distributed version control system
 
 extra:


### PR DESCRIPTION
from prebuilt kernel.org releases on `[not win]` platforms.  This enables the --help
option on all commands.

fixes #17

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
