### PR TITLE
Add htmldoc on [unix] and fix manpages on [osx]

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,3 +44,7 @@ popd # code
 # Install manpages
 mkdir -p $PREFIX/man
 cp -r manpages/* $PREFIX/man
+
+# Install htmldocs
+mkdir -p $PREFIX/share/doc/git
+cp -r htmldocs/* $PREFIX/share/doc/git

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,6 +44,12 @@ popd # code
 # Install manpages
 mkdir -p $PREFIX/man
 cp -r manpages/* $PREFIX/man
+# Add symlinks in $PREFIX/share/man so that manpages work on macOS
+if [[ $(uname) == "Darwin" ]]; then
+  ln -s $PREFIX/man/man1/git* $PREFIX/share/man/man1/
+  ln -s $PREFIX/man/man5/git* $PREFIX/share/man/man5/
+  ln -s $PREFIX/man/man7/git* $PREFIX/share/man/man7/
+fi
 
 # Install htmldocs
 mkdir -p $PREFIX/share/doc/git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,16 @@ source:
   - url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-{{ version }}.tar.gz  # [not win]
     folder: manpages  # [not win]
     sha256: ce995f86f441b56ab1fd0788a94786904ae2e2989e7191fd68060003011366d7  # [not win]
+  - url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-{{ version }}.tar.gz  # [not win]
+    folder: htmldocs  # [not win]
+    sha256: 650644d0f82a057f3fae934c49625ad972b2566e34852bb3c9b6ad405cd2dbc9  # [not win]
 
   - url: https://github.com/git-for-windows/git/releases/download/v{{ version }}.windows.1/PortableGit-{{ version }}-64-bit.7z.exe  # [win64]
     folder: .  # [win64]
     sha256: da1480896cf5a18b99b7bcea4b7e7e0fc9c9a1a521fe4c5df03db850381bb5e7  # [win64]
 
 build:
-  number: 0
+  number: 1
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
 
@@ -75,6 +78,9 @@ test:
 
     # confirm toplevel manpage
     - test -f $PREFIX/man/man1/git.1  # [not win]
+
+    # confirm toplevel html doc page
+    - test -f $PREFIX/share/doc/git/index.html  # [not win]
 
 about:
   home: https://git-scm.com/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,7 @@ test:
 
     # confirm toplevel manpage
     - test -f $PREFIX/man/man1/git.1  # [not win]
+    - test -f $PREFIX/share/man/man1/git.1  # [osx]
 
     # confirm toplevel html doc page
     - test -f $PREFIX/share/doc/git/index.html  # [not win]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #66 
<!--
Please add any other relevant info below:
-->

This PR adds the preformatted HTML Git documentation (`git help --web <command>`) and also adds symlinks from `$PREFIX/man/man?/` to  `$PREFIX/share/man/man?/` since the system `man` on macOS does not have the same logic as on Linux (see https://github.com/conda-forge/git-feedstock/issues/66#issuecomment-539095424).